### PR TITLE
Upgrade junit from 4.13.1 to 4.13.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -14,7 +14,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
 version.com.google.guava..guava=30.1-jre
 
-version.junit.junit=4.13.1
+version.junit.junit=4.13.2
 
 version.org.apache.commons..commons-lang3=3.11
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.