### PR TITLE
Upgrade guava from 30.1.1-android to 30.1.1-jre

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -12,7 +12,7 @@ plugin.org.danilopianini.publish-on-central=0.4.2
 
 plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
-version.com.google.guava..guava=30.1.1-android
+version.com.google.guava..guava=30.1.1-jre
 
 version.junit.junit=4.13.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.