### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.3 to 0.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,10 +18,6 @@ repositories {
     mavenCentral()
 }
 
-gitSemVer {
-    version = computeGitSemVer()
-}
-
 dependencies {
     implementation("com.google.guava:guava:_")
     implementation("org.apache.commons:commons-lang3:_")

--- a/versions.properties
+++ b/versions.properties
@@ -6,7 +6,7 @@
 
 plugin.com.github.spotbugs=4.7.1
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.3.0
 
 plugin.org.danilopianini.publish-on-central=0.5.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.