### PR TITLE
Upgrade spotbugs-annotations from 4.3.0 to 4.4.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,7 +17,7 @@ plugin.org.danilopianini.publish-on-central=0.5.0
 
 plugin.org.jlleitschuh.gradle.ktlint=10.1.0
 
-version.com.github.spotbugs..spotbugs-annotations=4.3.0
+version.com.github.spotbugs..spotbugs-annotations=4.4.0
 
 version.com.google.guava..guava=30.1.1-jre
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.